### PR TITLE
Refactor: Tooltip 및 Modal 컴포넌트 구조 리팩토링

### DIFF
--- a/src/app/(routes)/signup/page.tsx
+++ b/src/app/(routes)/signup/page.tsx
@@ -58,7 +58,7 @@ export default function SignupPage() {
                 <label className="block text-[1rem] font-medium text-[#1A1A1A]">
                   거주 지역
                 </label>
-                <Tooltip />
+                <Tooltip text="현재는 서울에서만 서비스 이용이 가능해요" />
               </div>
               <RegionSelector />
             </div>

--- a/src/components/atoms/Modal/Modal.tsx
+++ b/src/components/atoms/Modal/Modal.tsx
@@ -3,13 +3,36 @@
 interface ModalProps {
   children: React.ReactNode;
   onClose: () => void;
+  position?: "center" | "bottom";
+  disableOutsideClick?: boolean;
 }
 
-export default function Modal({ children, onClose }: ModalProps) {
+export default function Modal({
+  children,
+  onClose,
+  position = "bottom",
+  disableOutsideClick = false,
+}: ModalProps) {
+  const handleOutsideClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!disableOutsideClick && e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40">
-      <div className="relative w-full max-w-md rounded-t-2xl bg-[#F6F6F6]">
-        <button onClick={onClose} className="absolute top-4 right-4 text-2xl">
+    <div
+      className={`fixed inset-0 z-50 flex items-end bg-black/40 ${position === "center" ? "justify-center" : " "}`}
+      onClick={handleOutsideClick}
+    >
+      <div
+        className={`relative w-full max-w-md bg-[#F6F6F6] ${
+          position === "center" ? "rounded-t-2xl" : "mt-auto rounded-t-2xl"
+        }`}
+      >
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 cursor-pointer text-2xl"
+        >
           ×
         </button>
         {children}

--- a/src/components/atoms/Tooltip/Tooltip.tsx
+++ b/src/components/atoms/Tooltip/Tooltip.tsx
@@ -2,7 +2,11 @@
 
 import TooltipIcon from "@/assets/icons/tooltip-icon.svg";
 
-export default function Tooltip() {
+interface TooltipProps {
+  text: string;
+}
+
+export default function Tooltip({ text }: TooltipProps) {
   return (
     <div className="group relative flex items-center">
       <div className="cursor-pointer">
@@ -10,7 +14,7 @@ export default function Tooltip() {
       </div>
       <div className="invisible absolute bottom-full left-1/2 z-10 mb-2 w-max -translate-x-1/3 group-hover:visible">
         <div className="relative rounded-md bg-[#1A1A1A] px-3 py-2 text-xs text-white shadow">
-          현재는 서울에서만 서비스 이용이 가능해요
+          {text}
           <div className="absolute -bottom-1 left-1/3 h-2 w-2 -translate-x-1/2 rotate-45 bg-[#1A1A1A]" />
         </div>
       </div>

--- a/src/components/molecules/AgreementPopup.tsx
+++ b/src/components/molecules/AgreementPopup.tsx
@@ -21,7 +21,7 @@ export default function AgreementPopup({
         <button
           onClick={onClose}
           aria-label="닫기"
-          className="flex items-center justify-center"
+          className="flex cursor-pointer items-center justify-center"
         >
           <BackArrow />
         </button>
@@ -37,7 +37,7 @@ export default function AgreementPopup({
       <button
         type="button"
         onClick={onConfirm}
-        className="mt-6 w-full rounded-xl bg-[#59AC6E] py-3 text-sm font-medium text-white"
+        className="mt-6 w-full cursor-pointer rounded-xl bg-[#59AC6E] py-3 text-sm font-medium text-white"
       >
         확인
       </button>

--- a/src/components/molecules/RegionSelector.tsx
+++ b/src/components/molecules/RegionSelector.tsx
@@ -87,14 +87,22 @@ export default function RegionSelector() {
     const fullRegion = `${selectedGu} ${selectedDong}`;
     setValue("region", fullRegion);
     setOpen(false);
-    setStep("GU");
-    setSelectedGu("");
-    setSelectedDong("");
+    resetState();
   };
 
   const handleClose = () => {
     setOpen(false);
     resetState();
+  };
+
+  const isButtonDisabled = () => {
+    if (step === "GU") {
+      return !selectedGu;
+    }
+    if (step === "DONG") {
+      return !selectedDong;
+    }
+    return false;
   };
 
   return (
@@ -107,7 +115,7 @@ export default function RegionSelector() {
       </div>
 
       {open && (
-        <Modal onClose={handleClose}>
+        <Modal onClose={handleClose} position="center">
           <div className="flex flex-col gap-9 p-6">
             <h2 className="text-xl font-bold">
               {step === "GU" ? (
@@ -135,7 +143,7 @@ export default function RegionSelector() {
                           ? handleGuSelect(name)
                           : handleDongSelect(name)
                       }
-                      className={`rounded-xl px-4 py-3 text-sm font-medium ${
+                      className={`cursor-pointer rounded-xl px-4 py-3 text-sm font-medium ${
                         isSelected
                           ? "bg-[#59AC6E] text-white"
                           : "bg-white text-[#1A1A1A]"
@@ -149,9 +157,9 @@ export default function RegionSelector() {
             </div>
 
             <button
-              disabled={step === "DONG" && !selectedDong}
+              disabled={isButtonDisabled()}
               onClick={step === "GU" ? () => setStep("DONG") : handleComplete}
-              className="mt-6 w-full rounded-xl bg-[#59AC6E] py-3 text-white disabled:opacity-50"
+              className="mt-6 w-full cursor-pointer rounded-xl bg-[#59AC6E] py-3 text-white disabled:cursor-auto disabled:opacity-50"
             >
               {step === "GU" ? "다음" : "완료"}
             </button>


### PR DESCRIPTION
## 작업의 목적
- Tooltip과 Modal 컴포넌트의 확장성과 재사용성을 고려하여 props를 추가하고 구조를 리팩토링합니다.

## 기대효과
- Tooltip 컴포넌트가 다양한 텍스트를 props로 받아 사용할 수 있어 재사용성이 높아집니다.
- Modal 컴포넌트가 position과 disableOutsideClick props를 통해 다양한 위치와 동작을 제어할 수 있어 확장성과 유연성이 강화됩니다.


## 주요 구현 사항
- Tooltip 컴포넌트를 수정하여 하드코딩된 텍스트 대신 `text` props를 받아 표시하도록 개선
- Modal 컴포넌트에 `position("bottom" | "center")` props를 추가하여 모달 위치 제어 가능
- Modal 컴포넌트에 `disableOutsideClick` props를 추가하여 외부 클릭 시 닫힘 여부를 제어
- 조건부 스타일링(className) 및 외부 클릭 핸들링 로직 추가
- 수정된 props 스펙에 맞춰 기존 컴포넌트 사용처 수정

closed #27
