### PR TITLE
Feat: OAuth 로그인 연동

### DIFF
--- a/src/api/oauth/google.ts
+++ b/src/api/oauth/google.ts
@@ -1,17 +1,3 @@
-const GOOGLE_CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!;
-const REDIRECT_URI = `${process.env.NEXT_PUBLIC_REDIRECT_URI}/auth/google/callback`; // 백엔드와 반드시 일치해야 함
-const SCOPE = "openid email profile";
-
 export const getGoogleAuthURL = () => {
-  const baseUrl = "https://accounts.google.com/o/oauth2/v2/auth";
-  const config: Record<string, string> = {
-    client_id: GOOGLE_CLIENT_ID,
-    redirect_uri: REDIRECT_URI,
-    response_type: "code",
-    scope: SCOPE,
-    access_type: "offline", //  refresh_token을 발급받기 위한 설정
-    prompt: "consent", //  계정 선택 창을 항상 표시
-  };
-
-  return `${baseUrl}?${new URLSearchParams(config).toString()}`;
+  return `${process.env.NEXT_PUBLIC_SERVER_URL}/oauth2/authorization/google`;
 };

--- a/src/api/oauth/loginWithOauthCode.ts
+++ b/src/api/oauth/loginWithOauthCode.ts
@@ -1,10 +1,22 @@
 import { requestHandler } from "@/lib/axiosInstance";
 
+interface OAuthLoginResponse {
+  user: {
+    id: number;
+    email: string;
+    nickname: string;
+    provider: "GOOGLE" | "KAKAO";
+    registered: boolean;
+  };
+  accessToken: string;
+  refreshToken: string;
+}
+
 export const loginWithOauthCode = async (
   provider: "kakao" | "google",
   code: string,
-) => {
-  const url = `/auth/${provider}`; // TODO: 백엔드 엔드포인트 확정 시 수정
+): Promise<OAuthLoginResponse> => {
+  const url = `/auth/${provider}`;
   const payload = { code };
 
   return await requestHandler("post", url, payload);

--- a/src/app/(routes)/login/oauth2/code/google/page.tsx
+++ b/src/app/(routes)/login/oauth2/code/google/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 export const dynamic = "force-dynamic";
 
 import GoogleCallbackClient from "@/components/pages/oauth/GoogleCallbackClient";

--- a/src/app/(routes)/login/oauth2/code/google/page.tsx
+++ b/src/app/(routes)/login/oauth2/code/google/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export const dynamic = "force-dynamic";
+
+import GoogleCallbackClient from "@/components/pages/oauth/GoogleCallbackClient";
+
+export default function GoogleCallbackPage() {
+  return <GoogleCallbackClient />;
+}

--- a/src/app/(routes)/oauth/googlecallback/page.tsx
+++ b/src/app/(routes)/oauth/googlecallback/page.tsx
@@ -1,7 +1,0 @@
-export const dynamic = "force-dynamic";
-
-import GoogleCallbackClient from "@/components/pages/oauth/GoogleCallbackClient";
-
-export default function GoogleCallbackPage() {
-  return <GoogleCallbackClient />;
-}

--- a/src/hooks/mutations/useOauthLogin.tsx
+++ b/src/hooks/mutations/useOauthLogin.tsx
@@ -2,6 +2,18 @@ import { useMutation } from "@tanstack/react-query";
 import { loginWithOauthCode } from "@/api/oauth/loginWithOauthCode";
 import { useAuthStore } from "@/stores/useAuthStore";
 
+interface LoginResponse {
+  user: {
+    id: number;
+    email: string;
+    nickname: string;
+    provider: "GOOGLE" | "KAKAO";
+    registered: boolean;
+  };
+  accessToken: string;
+  refreshToken: string;
+}
+
 export const useOauthLogin = () => {
   const { login } = useAuthStore();
 
@@ -13,8 +25,20 @@ export const useOauthLogin = () => {
       provider: "kakao" | "google";
       code: string;
     }) => loginWithOauthCode(provider, code),
-    onSuccess: () => {
-      login(); // 백엔드 응답 구조와 상관없이 로그인 상태만 설정
+
+    onSuccess: (data: LoginResponse) => {
+      const { user, accessToken, refreshToken } = data;
+
+      login({
+        user: {
+          id: user.id,
+          email: user.email,
+          nickname: user.nickname,
+          provider: user.provider,
+        },
+        accessToken,
+        refreshToken,
+      });
     },
   });
 };

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,9 +1,23 @@
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
+export interface User {
+  id: number;
+  email: string;
+  nickname: string;
+  provider: "GOOGLE" | "KAKAO";
+}
+
 interface AuthState {
   isLoggedIn: boolean;
-  login: () => void;
+  user: User | null;
+  accessToken: string | null;
+  refreshToken: string | null;
+  login: (payload: {
+    user: User;
+    accessToken: string;
+    refreshToken: string;
+  }) => void;
   logout: () => void;
 }
 
@@ -12,15 +26,32 @@ export const useAuthStore = create<AuthState>()(
     persist(
       (set) => ({
         isLoggedIn: false,
-        login: () => set({ isLoggedIn: true }),
-        logout: () => set({ isLoggedIn: false }),
+        user: null,
+        accessToken: null,
+        refreshToken: null,
+
+        login: ({ user, accessToken, refreshToken }) =>
+          set({
+            isLoggedIn: true,
+            user,
+            accessToken,
+            refreshToken,
+          }),
+
+        logout: () =>
+          set({
+            isLoggedIn: false,
+            user: null,
+            accessToken: null,
+            refreshToken: null,
+          }),
       }),
       {
-        name: "auth-storage", // localStorage에 표시되는 key 이름
+        name: "auth-storage", // localStorage에 저장될 키 이름
       },
     ),
     {
-      name: "AuthStore", // Redux Devtools에서 표시되는 store 이름
+      name: "AuthStore", // Redux Devtools에서 표시될 이름
     },
   ),
 );


### PR DESCRIPTION
## 작업의 목적
- 백엔드 Google OAuth 연동이 완료됨에 따라, 프론트에서 사용자 정보 처리 및 로그인 분기 로직 구현

## 기대효과
- 실제 구글 계정으로 로그인 가능
- 신규 유저일 경우 `/signup`, 기존 유저는 `/home`으로 자동 분기
- Zustand를 통한 사용자 정보 및 토큰 상태 저장 구조 적용
- 포트폴리오에서 소셜 로그인 구현 흐름, 상태 관리 및 보안 처리까지 어필 가능

## 주요 구현 사항
- 백엔드 제공 인증 URL(`/oauth2/authorization/google`)로 리디렉트 처리
- 콜백 처리용 페이지(`/login/oauth2/code/google`)에서 accessToken, refreshToken, user 정보 수신
- Zustand `useAuthStore` 확장: 사용자 정보 및 토큰 상태 저장 구조 도입
- 응답 기반으로 `/signup` 또는 `/home`으로 리다이렉트 처리
- 로그인 버튼 및 로딩 처리 UI 구현

closed #63 
