### PR TITLE
Feat: 로그아웃 기능 구현

### DIFF
--- a/src/components/organisms/DropdownList.tsx
+++ b/src/components/organisms/DropdownList.tsx
@@ -4,7 +4,7 @@ interface Props {
 
 function DropdownList({ children }: Props) {
   return (
-    <div className="flex flex-col gap-4.5 rounded-xl border-[0.8px] border-[#B0B0B0] bg-white px-3.5 py-5">
+    <div className="flex w-64 flex-col gap-4.5 rounded-xl border-[0.8px] border-[#B0B0B0] bg-white px-3.5 py-5">
       {children}
     </div>
   );

--- a/src/components/organisms/profile/EditProfileForm.tsx
+++ b/src/components/organisms/profile/EditProfileForm.tsx
@@ -3,6 +3,7 @@
 import { useForm, FormProvider } from "react-hook-form";
 import ProfileImageUploader from "@/components/molecules/profile/ProfileImageUploader";
 import NicknameField from "@/components/molecules/profile/NicknameField";
+import { useLogout } from "@/hooks/mutations/useLogout";
 
 interface EditProfileFormProps {
   onWithdraw: () => void;
@@ -16,13 +17,19 @@ export default function EditProfileForm({ onWithdraw }: EditProfileFormProps) {
     },
   });
 
+  const { handleLogout } = useLogout();
+
   return (
     <FormProvider {...methods}>
       <form>
         <ProfileImageUploader />
         <NicknameField />
         <div className="text-body2-medium font-gsans-medium text-grey-400 mt-6 flex items-center justify-center gap-3">
-          <button type="button" className="border-r border-[#D9D9D9] pr-3">
+          <button
+            type="button"
+            className="border-r border-[#D9D9D9] pr-3"
+            onClick={handleLogout}
+          >
             로그아웃
           </button>
           <button type="button" onClick={onWithdraw}>

--- a/src/hooks/mutations/useLogout.ts
+++ b/src/hooks/mutations/useLogout.ts
@@ -1,0 +1,25 @@
+import { useRouter } from "next/navigation";
+import axios from "axios";
+import { useAuthStore } from "@/stores/useAuthStore";
+
+export const useLogout = () => {
+  const router = useRouter();
+  const logout = useAuthStore((state) => state.logout);
+
+  const handleLogout = async () => {
+    try {
+      await axios.post(
+        `${process.env.NEXT_PUBLIC_SERVER_URL}/api/auth/logout`,
+        {},
+        { withCredentials: true },
+      );
+      logout();
+      router.replace("/login");
+    } catch (error) {
+      console.error("로그아웃 실패:", error);
+      alert("로그아웃에 실패했습니다. 다시 시도해주세요.");
+    }
+  };
+
+  return { handleLogout };
+};

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -32,18 +32,25 @@ export const useAuthStore = create<AuthState>()(
             user,
           }),
 
-        logout: () =>
+        logout: () => {
+          // 상태 초기화
           set({
             isLoggedIn: false,
             user: null,
-          }),
+          });
+
+          // localStorage에서 persist된 상태 삭제
+          if (typeof window !== "undefined") {
+            localStorage.removeItem("auth-storage");
+          }
+        },
       }),
       {
-        name: "auth-storage",
+        name: "auth-storage", // localStorage에 저장될 키
       },
     ),
     {
-      name: "AuthStore",
+      name: "AuthStore", // Redux Devtools에 표시될 이름
     },
   ),
 );

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -4,6 +4,12 @@ import { devtools, persist } from "zustand/middleware";
 export interface User {
   id: number;
   email: string;
+  nickname: string;
+  gender: "male" | "female";
+  provider: "KAKAO" | "GOOGLE";
+  registered: boolean;
+  region: string; // 예: "강남구 개포동"
+  profileImageUrl: string;
 }
 
 interface AuthState {


### PR DESCRIPTION
## 작업의 목적
- 프로필 수정 페이지에서 로그아웃 기능을 구현하여, 사용자가 명시적으로 세션을 종료할 수 있도록 하기 위함

## 기대효과
- 유저가 `/edit` 또는 기타 페이지에서 로그아웃 버튼 클릭 시 세션이 안전하게 종료되고, 로그인 페이지(`/login`)로 리디렉션됨
- zustand에 저장된 사용자 정보 및 로그인 상태도 초기화되어, 보안적으로 안전한 상태 유지

## 주요 구현 사항
- 로그아웃 요청을 위한 `POST /api/auth/logout` API 호출 로직 구현 (`withCredentials: true`)
- 로그아웃 성공 시 zustand `logout()` 메서드 호출 → 로그인 상태 및 사용자 정보 초기화
- router.replace를 통해 `/login` 페이지로 리디렉션 처리
- `handleLogout` 로직을 `hooks/mutations/useLogout.ts`로 분리하여 재사용성 및 테스트 용이성 확보


