### PR TITLE
Feat: 완료된 모임 목록 / 상세 조회 연결

### DIFF
--- a/src/api/gatherings/gatherings.ts
+++ b/src/api/gatherings/gatherings.ts
@@ -23,8 +23,11 @@ export const fetchClosedgatheringList = async (
   return await requestHandler("get", `/api/post/list/rec${query}`);
 };
 
-export const fetchCompletedGatheringList = async () => {
-  return await requestHandler("get", "/api/post/list/com");
+export const fetchCompletedGatheringList = async (
+  payload: IFetchGatheringListRequest,
+) => {
+  const query = `?page=${payload.page}&size=${payload.size}`;
+  return await requestHandler("get", `/api/post/list/com${query}`);
 };
 
 export const fetchGatheringDetail = async (postId: number) => {

--- a/src/app/(routes)/gatherings/completed/[id]/layout.tsx
+++ b/src/app/(routes)/gatherings/completed/[id]/layout.tsx
@@ -1,0 +1,12 @@
+import CompletedGatheringHeader from "@/components/organisms/header/CompletedGatheringHeader";
+
+function GatheringDetailLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <CompletedGatheringHeader title="완료된 모임" backButton />
+      <div>{children}</div>
+    </div>
+  );
+}
+
+export default GatheringDetailLayout;

--- a/src/app/(routes)/gatherings/completed/layout.tsx
+++ b/src/app/(routes)/gatherings/completed/layout.tsx
@@ -3,9 +3,9 @@ import Nav from "@/components/organisms/Nav";
 
 function CompletedGatheringLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div>
+    <div className="flex flex-col">
       <CompletedGatheringHeader title="지난 모임" backButton />
-      <div>{children}</div>
+      <div className="bottom-padding flex-1">{children}</div>
       <Nav />
     </div>
   );

--- a/src/app/(routes)/gatherings/completed/page.tsx
+++ b/src/app/(routes)/gatherings/completed/page.tsx
@@ -1,15 +1,12 @@
-import GatheringCreateButton from "@/components/atoms/Button/GatheringCreateButton";
-import { gatherings } from "@/data/gatherings";
-import GatheringList from "../../../../components/organisms/gatherings/GatheringList";
+import GatheringCompletedTemplate from "@/components/templates/GatheringCompletedTemplate";
 
-export default function Gathering() {
+export default function GatheringCompletedPage() {
   return (
     <div className="flex flex-col gap-5">
       <h1 className="justify-start text-xl leading-normal font-bold text-[#1A1A1A]">
         동네에 이런 모임이 있었어요 🔥
       </h1>
-      <GatheringList gatherings={gatherings} />
-      <GatheringCreateButton />
+      <GatheringCompletedTemplate />
     </div>
   );
 }

--- a/src/app/(routes)/home/layout.tsx
+++ b/src/app/(routes)/home/layout.tsx
@@ -1,0 +1,12 @@
+import Nav from "@/components/organisms/Nav";
+
+function HomeLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col">
+      <div className="bottom-padding flex-1">{children}</div>
+      <Nav />
+    </div>
+  );
+}
+
+export default HomeLayout;

--- a/src/components/organisms/Nav.tsx
+++ b/src/components/organisms/Nav.tsx
@@ -45,24 +45,29 @@ const NAV_ITEM_STYLE = {
 
 export default function Nav() {
   const pathname = usePathname();
-  const pathnameFirst = pathname.split("/")[1];
-  console.log(pathnameFirst);
   return (
     <div className="shadow-[0px_4px_24px_0px_rgba(170,170,170,0.30)]justify-center fixed bottom-0 flex w-96 w-full max-w-[500px] items-end bg-white px-10 pt-2.5 pb-5">
-      {NAV_ITEMS.map((item, index) => (
-        <Link
-          key={index}
-          href={item.href}
-          className={`flex flex-1 flex-col items-center justify-center gap-0.5 ${`/${pathnameFirst}` === item.href ? NAV_ITEM_STYLE.active.icon : NAV_ITEM_STYLE.default.icon}`}
-        >
-          {item.icon}
-          <div
-            className={`text-body3-medium ${`/${pathnameFirst}` === item.href ? NAV_ITEM_STYLE.active.text : NAV_ITEM_STYLE.default.text}`}
+      {NAV_ITEMS.map((item, index) => {
+        const isActive =
+          item.href === "/home"
+            ? pathname === "/home"
+            : pathname.startsWith(item.href);
+
+        return (
+          <Link
+            key={index}
+            href={item.href}
+            className={`flex flex-1 flex-col items-center justify-center gap-0.5 ${isActive ? NAV_ITEM_STYLE.active.icon : NAV_ITEM_STYLE.default.icon}`}
           >
-            {item.label}
-          </div>
-        </Link>
-      ))}
+            {item.icon}
+            <div
+              className={`text-body3-medium ${isActive ? NAV_ITEM_STYLE.active.text : NAV_ITEM_STYLE.default.text}`}
+            >
+              {item.label}
+            </div>
+          </Link>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/organisms/Nav.tsx
+++ b/src/components/organisms/Nav.tsx
@@ -18,7 +18,7 @@ const NAV_ITEMS = [
   {
     label: "모임",
     icon: <GatheringIcon className={iconStyle} />,
-    href: `/gatherings`,
+    href: `/gatherings/completed`,
   },
   {
     label: "랭킹",

--- a/src/components/organisms/gatherings/GatheringList.tsx
+++ b/src/components/organisms/gatherings/GatheringList.tsx
@@ -1,32 +1,32 @@
-"use client"
+"use client";
 
-import { IGatheringItem } from "@/types/gatherings";
-import { getDay, getDayOfWeek, getMonth } from "@/utils/day";
-import { groupGatheringsByDate } from "@/utils/gatherings";
-import DateBadge from "../../atoms/Badge/DateBadge";
-import GatheringItem from "./GatheringItem";
+import { useFetchCompletedGatheringList } from "@/hooks/queries/useFetchGatheringList";
 
-interface Props {
-    gatherings: IGatheringItem[];
+export default function GatheringList() {
+  const { data } = useFetchCompletedGatheringList();
+  console.log(data);
+
+  // const groupedGatherings = groupGatheringsByDate(data);
+  return <div>안녕</div>;
+  //
+  //return (
+  //  <div className="flex flex-col gap-5">
+  //    {groupedGatherings.map((gatherings, index) => (
+  //      <div className="flex flex-row gap-2" key={index}>
+  //        <div>
+  //          <DateBadge
+  //            month={getMonth(gatherings[0].meetingTime)}
+  //            day={getDay(gatherings[0].meetingTime)}
+  //            dayOfWeek={getDayOfWeek(gatherings[0].meetingTime)}
+  //          />
+  //        </div>
+  //        <div className="flex flex-1 flex-col gap-5">
+  //          {gatherings.map((gathering, index) => (
+  //            <GatheringItem {...gathering} key={index} />
+  //          ))}
+  //        </div>
+  //      </div>
+  //    ))}
+  //  </div>
+  //);
 }
-export default function GatheringList({ gatherings }: Props) {
-    const groupedGatherings = groupGatheringsByDate(gatherings);
-
-    return (
-        <div className="flex flex-col gap-5">
-            {groupedGatherings.map((gatherings, index) => (
-                <div className="flex flex-row gap-2" key={index}>
-                    <div>
-                        <DateBadge month={getMonth(gatherings[0].meetingTime)} day={getDay(gatherings[0].meetingTime)} dayOfWeek={getDayOfWeek(gatherings[0].meetingTime)} />
-                    </div>
-                    <div className="flex flex-col gap-5 flex-1">
-                        {gatherings.map((gathering, index) => (
-                            <GatheringItem {...gathering} key={index} />
-                        ))}
-                    </div>
-                </div>
-            ))}
-        </div>
-    );
-}
-

--- a/src/components/templates/GatheringCompletedTemplate.tsx
+++ b/src/components/templates/GatheringCompletedTemplate.tsx
@@ -1,0 +1,13 @@
+import GatheringCreateButton from "@/components/atoms/Button/GatheringCreateButton";
+import GatheringList from "@/components/organisms/gatherings/GatheringList";
+
+function GatheringCompletedTemplate() {
+  return (
+    <div>
+      <GatheringList />
+      <GatheringCreateButton />
+    </div>
+  );
+}
+
+export default GatheringCompletedTemplate;

--- a/src/components/templates/GatheringsCreatePage.tsx
+++ b/src/components/templates/GatheringsCreatePage.tsx
@@ -31,11 +31,7 @@ export default function GatheringsCreatePage() {
     mode: "onChange",
   });
 
-  const {
-    handleSubmit,
-    formState: { isValid },
-    watch,
-  } = methods;
+  const { handleSubmit, watch } = methods;
 
   const title = watch(TITLE);
   const content = watch(CONTENT);
@@ -159,7 +155,7 @@ export default function GatheringsCreatePage() {
             />
           </InputWithLabel>
         </div>
-        <InputWithLabel label="카카오톡 링크" name={OPEN_CHAT_URL}>
+        <InputWithLabel label="카카오톡 오픈채팅방 (선택)" name={OPEN_CHAT_URL}>
           <InputWithKaKaoLink
             name={OPEN_CHAT_URL}
             placeholder="오픈채팅방 링크를 공유해주세요."
@@ -168,7 +164,7 @@ export default function GatheringsCreatePage() {
         </InputWithLabel>
 
         <CreateButton
-          isActive={isActive && isValid}
+          isActive={isActive}
           message="모임장은 모인 후에 최소 사진 1장을 올려주셔야 해요"
         >
           완료

--- a/src/hooks/queries/useFetchGatheringList.ts
+++ b/src/hooks/queries/useFetchGatheringList.ts
@@ -1,8 +1,11 @@
 import {
   fetchClosedgatheringList,
+  fetchCompletedGatheringList,
   fetchOngoingGatheringList,
 } from "@/api/gatherings/gatherings";
 import {
+  IFetchGatheringCompletedLisContent,
+  IFetchGatheringCompletedListResponse,
   IFetchGatheringListResponse,
   IGatheringItem,
 } from "@/types/gatherings";
@@ -48,4 +51,31 @@ export const useFetchGatheringList = (closed: boolean, pos: string) => {
 export const useFetchClosedGatheringList = () => {};
 
 /** 모임 화면 - 활동이 완료된 모임 */
-export const useFetchCompletedGatheringList = () => {};
+export const useFetchCompletedGatheringList = () => {
+  const { data, fetchNextPage, hasNextPage, refetch } =
+    useInfiniteQuery<IFetchGatheringCompletedListResponse>({
+      queryKey: ["fetchGatheringCompletedList"],
+      queryFn: ({ pageParam }) => {
+        const payload = {
+          page: pageParam as number,
+          size: ROWS_PER_PAGE,
+        };
+        return fetchCompletedGatheringList(payload);
+      },
+      getNextPageParam: (lastPage) => {
+        const nextPage = lastPage.page + 1;
+        return lastPage.totalPages - 1 !== lastPage.page ? nextPage : undefined;
+      },
+      initialPageParam: 0,
+    });
+
+  const response: IFetchGatheringCompletedLisContent[] =
+    data?.pages.flatMap((page) => page.content) || [];
+
+  return {
+    fetchNextPage,
+    hasNextPage,
+    refetch,
+    data: response,
+  };
+};

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -121,6 +121,10 @@
     }
     scrollbar-width: none;
   }
+
+  .bottom-padding {
+    @apply pb-[95px];
+  }
 }
 
 @layer components {

--- a/src/types/gatherings.ts
+++ b/src/types/gatherings.ts
@@ -34,7 +34,7 @@ export interface ICreateGatheringRequest {
 }
 
 export interface IFetchGatheringListRequest {
-  pos: string;
+  pos?: string;
   page: number;
   size: number;
   sort?: string[];
@@ -81,4 +81,28 @@ export interface IFetchGatheringDetailResponse {
     imageUrls?: string[];
     iin: boolean; // 작성자이거나 참여자일 때
   };
+}
+
+export interface IFetchGatheringCompletedListResponse {
+  content: IFetchGatheringCompletedLisContent[];
+  page: number;
+  size: number;
+  totalPages: number;
+  totalElements: number;
+  timestamp: string;
+}
+
+export interface IFetchGatheringCompletedLisContent {
+  id: number;
+  title: string;
+  meetingTime: string;
+  placeName: string;
+  address: string;
+  participantCount: number;
+  participants: IParticipant[];
+  thumnail: string;
+  latitiude: number;
+  longtitude: number;
+  maxParticipants: number;
+  inn: boolean;
 }


### PR DESCRIPTION
## 작업의 목적
- 완료된 모임 조회, 목록 조회 API 연결하는 작업입니다.

## 보완
- 백엔드 API 이슈로 목록 조회 API는 연결 테스트하지 못한 상태입니다.
- 이미지 화면에 보여주는 방식
(현재) 상세 조회 > 여러 이미지  추출 > 이미지들 각각 GET 요청 > Blob 파일 > URL 변환 후 화면에 렌더링
복잡한 흐름을 개선하기 위해 백엔드에 요청해놓은 상태입니다.

## 기대효과
- 포트폴리오에 활용할 예정이니 자세하게 적어주세요

## 주요 구현 사항
- 완료된 모임 조회, 목록 조회 API 연결
- 네비바가 있을 경우 `bottom-padding` 을 `global.css`에 정의
  
closed #85 
