### PR TITLE
Fix: 서울 외 지역에 대한 에러처리

### DIFF
--- a/src/components/molecules/homefeed/LocationSelectorDropdown.tsx
+++ b/src/components/molecules/homefeed/LocationSelectorDropdown.tsx
@@ -3,6 +3,7 @@
 import IconDropdown from "@/assets/icons/dropdown-arrow.svg";
 import DropdownItem from "@/components/molecules/DropdownItem";
 import DropdownList from "@/components/organisms/DropdownList";
+import { ERROR_MESSAGES } from "@/constants/errorMessage";
 import { useReverseGeocode } from "@/hooks/queries/useRegions";
 import { useUserProfile } from "@/hooks/queries/useUserProfile";
 import { useState } from "react";
@@ -48,12 +49,19 @@ export default function LocationSelectorDropdown({
       refetch()
         .then(({ data }) => {
           if (data && data.data) {
+            if (data.data.city !== "서울특별시") {
+              throw new Error(ERROR_MESSAGES.NOT_SEOUL);
+            }
             onSelect(`${data.data.district} ${data.data.neighborhood}`);
             setWhere("현재 위치한 지역 (동)");
           }
         })
-        .catch(() => {
-          showToast("위치 정보를 가져오는데 실패했습니다.");
+        .catch((error) => {
+          showToast(
+            error.message === ERROR_MESSAGES.NOT_SEOUL
+              ? ERROR_MESSAGES.NOT_SEOUL
+              : ERROR_MESSAGES.LOCATION_FETCH_FAIL,
+          );
           setWhere("내 거주지역");
         });
     }

--- a/src/constants/errorMessage.ts
+++ b/src/constants/errorMessage.ts
@@ -1,0 +1,4 @@
+export const ERROR_MESSAGES = {
+  NOT_SEOUL: "현재는 서울에서만 서비스 이용이 가능해요",
+  LOCATION_FETCH_FAIL: "위치 정보를 가져오는데 실패했습니다.",
+};


### PR DESCRIPTION

# 주요 구현 사항
- 백엔드에서 `reverseGeocode` API 응답시, 서울 외 지역에 대한 에러 처리
- city 필드값이 "서울특별시"가 아닐 경우, 토스트 알림
- 에러 메시지 상수 파일 생성

closed #97 
