### PR TITLE
Fix: 프로필 이미지 속성 추가

### DIFF
--- a/src/components/atoms/ProfileImage/ProfileImage.tsx
+++ b/src/components/atoms/ProfileImage/ProfileImage.tsx
@@ -16,7 +16,10 @@ export default function ProfileImage({ src, size = 28 }: Props) {
         className="relative overflow-hidden rounded-full"
         style={{ width: size, height: size }}
       >
-        <Avatar className="h-7 w-7 rounded-full" />
+        <Avatar
+          className="rounded-full"
+          style={{ width: size, height: size }}
+        />
       </div>
     );
   }

--- a/src/components/organisms/profile/ProfileHeader.tsx
+++ b/src/components/organisms/profile/ProfileHeader.tsx
@@ -24,11 +24,14 @@ export default function ProfileHeader({
     <section className="mb-6 flex items-center justify-between px-2">
       <div className="flex items-center gap-3">
         {profileImageUrl ? (
-          <Image
-            src={profileImageUrl}
-            alt="프로필 이미지"
-            className="h-14 w-14 rounded-full object-cover"
-          />
+          <div className="relative h-14 w-14 overflow-hidden rounded-full">
+            <Image
+              src={profileImageUrl}
+              alt="프로필 이미지"
+              fill
+              className="object-cover"
+            />
+          </div>
         ) : (
           <Avatar className="h-14 w-14 rounded-full" />
         )}

--- a/src/components/templates/HomeFeedTemplate.tsx
+++ b/src/components/templates/HomeFeedTemplate.tsx
@@ -35,10 +35,10 @@ export default function HomeFeedTemplate({
   const { data: userProfile } = useUserProfile();
 
   useEffect(() => {
-    if (!region && userProfile?.region) {
+    if (userProfile?.region) {
       setRegion(userProfile.region);
     }
-  }, [userProfile?.region, region, setRegion]);
+  }, [userProfile?.region, setRegion]);
 
   const {
     data: gatheringList,


### PR DESCRIPTION
## 작업의 목적
- 프로필 페이지의 프로필 이미지 UI 고정

## 기대효과
- 프로필 이미지의 사이즈에 상관없이 일관성 있는 사이즈 고정

## 주요 구현 사항
- Image태그를 div태그로 감싸고 Image태그에 fill 속성과 object-cover를 이용해 사이즈 설정
  
closed #이슈번호
