### PR TITLE
fix: 닉네임 수정 버튼 레이아웃 수정

### DIFF
--- a/src/components/organisms/profile/ProfileHeader.tsx
+++ b/src/components/organisms/profile/ProfileHeader.tsx
@@ -2,6 +2,7 @@
 
 import Avatar from "@/assets/icons/avatar.svg";
 import IconChevronRight from "@/assets/icons/IconChevronRight.svg";
+import { useImageUrl } from "@/utils/useImageUrl";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 
@@ -20,13 +21,15 @@ export default function ProfileHeader({
     router.push("/profile/edit");
   };
 
+  const imageUrl = useImageUrl(profileImageUrl);
+
   return (
     <section className="mb-6 flex items-center justify-between px-2">
       <div className="flex items-center gap-3">
         {profileImageUrl ? (
           <div className="relative h-14 w-14 overflow-hidden rounded-full">
             <Image
-              src={profileImageUrl}
+              src={imageUrl}
               alt="프로필 이미지"
               fill
               className="object-cover"

--- a/src/components/templates/EditNicknameTemplate.tsx
+++ b/src/components/templates/EditNicknameTemplate.tsx
@@ -22,14 +22,11 @@ export default function EditNicknameTemplate({
   const nickname = watch("nickname");
 
   return (
-    <div className="h-full w-full">
+    <div className="flex min-h-screen flex-col">
       <Header title="닉네임 변경" backButton />
 
-      <form
-        onSubmit={onSubmit}
-        className="flex h-full w-full flex-col justify-between pb-10"
-      >
-        <div className="relative">
+      <form onSubmit={onSubmit} className="flex flex-1 flex-col px-5">
+        <div className="relative pt-6">
           <label className="text-body1-medium font-gsans-medium text-grey-950 mb-2 block">
             새로운 닉네임을 입력해주세요
           </label>
@@ -53,15 +50,17 @@ export default function EditNicknameTemplate({
           )}
         </div>
 
-        <button
-          type="submit"
-          disabled={!isValid}
-          className={`text-body2-medium font-gsans-medium mt-6 w-full rounded-xl py-3 ${
-            isValid ? "bg-green text-white" : "bg-grey-200 text-grey-400"
-          }`}
-        >
-          확인
-        </button>
+        <div className="mt-auto mb-8">
+          <button
+            type="submit"
+            disabled={!isValid}
+            className={`text-body2-medium font-gsans-medium w-full rounded-xl py-3 ${
+              isValid ? "bg-green text-white" : "bg-grey-200 text-grey-400"
+            }`}
+          >
+            확인
+          </button>
+        </div>
       </form>
     </div>
   );


### PR DESCRIPTION
# 닉네임 수정 페이지 레이아웃 개선

## 작업의 목적
- 닉네임 수정 페이지의 UI/UX 개선을 통한 사용자 경험 향상

## 기대효과
- 스크롤 없이 모든 콘텐츠를 한 화면에서 확인


## 주요 구현 사항
- `min-h-screen`과 `flex flex-col` 적용으로 전체 화면 높이 활용
- 폼 요소들의 간격과 정렬을 flex 레이아웃으로 개선
- 입력 폼과 버튼의 좌우 패딩을 `px-5`로 통일하여 일관된 여백 유지



