### PR TITLE
Feat: 카카오톡 초대하기 기능 구현

### DIFF
--- a/src/app/(routes)/profile/invite/page.tsx
+++ b/src/app/(routes)/profile/invite/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect } from "react";
 import Empty from "@/components/organisms/Empty";
 import Header from "@/components/organisms/Header";
-import "@/types/kakao";
 
 export default function InvitePage() {
   useEffect(() => {

--- a/src/app/(routes)/profile/invite/page.tsx
+++ b/src/app/(routes)/profile/invite/page.tsx
@@ -1,12 +1,54 @@
 "use client";
 
+import { useEffect } from "react";
 import Empty from "@/components/organisms/Empty";
 import Header from "@/components/organisms/Header";
+import "@/types/kakao";
 
 export default function InvitePage() {
+  useEffect(() => {
+    // 이미 로드된 경우 중복 로드 방지
+    if (window.Kakao) return;
+
+    const script = document.createElement("script");
+    script.src = "https://developers.kakao.com/sdk/js/kakao.js";
+    script.async = true;
+    script.onload = () => {
+      if (window.Kakao && !window.Kakao.isInitialized()) {
+        window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY || "");
+      }
+    };
+    document.head.appendChild(script);
+  }, []);
+
   const handleKakaoInvite = () => {
-    // 추후 카카오톡 공유 API 연동 예정
-    alert("카카오톡으로 초대합니다 (추후 구현 예정)");
+    if (!window.Kakao || !window.Kakao.isInitialized()) {
+      alert(
+        "카카오 SDK가 아직 로드되지 않았습니다. 잠시 후 다시 시도해주세요.",
+      );
+      return;
+    }
+    window.Kakao.Link.sendDefault({
+      objectType: "feed",
+      content: {
+        title: "플로고에서 함께 줍깅해요!",
+        description: "동네 친구들과 줍깅 챌린지에 도전해보세요!",
+        imageUrl: "https://ploggo.co.kr/logo.png",
+        link: {
+          mobileWebUrl: "https://ploggo.co.kr",
+          webUrl: "https://ploggo.co.kr",
+        },
+      },
+      buttons: [
+        {
+          title: "플로고 바로가기",
+          link: {
+            mobileWebUrl: "https://ploggo.co.kr",
+            webUrl: "https://ploggo.co.kr",
+          },
+        },
+      ],
+    });
   };
 
   const handleSmsInvite = () => {

--- a/src/types/kakao.d.ts
+++ b/src/types/kakao.d.ts
@@ -1,0 +1,31 @@
+declare global {
+  interface Window {
+    Kakao: {
+      init: (apiKey: string) => void;
+      isInitialized: () => boolean;
+      Link: {
+        sendDefault: (options: {
+          objectType: string;
+          content: {
+            title: string;
+            description: string;
+            imageUrl: string;
+            link: {
+              mobileWebUrl: string;
+              webUrl: string;
+            };
+          };
+          buttons: Array<{
+            title: string;
+            link: {
+              mobileWebUrl: string;
+              webUrl: string;
+            };
+          }>;
+        }) => void;
+      };
+    };
+  }
+}
+
+export {}; // 이 파일이 모듈로 인식되도록 빈 export 추가


### PR DESCRIPTION
## 작업의 목적
- 사용자가 친구를 플로고에 초대할 수 있도록 카카오톡 공유 기능을 추가했습니다.
- 기존 문자 초대 기능과 함께, 카카오톡을 통한 초대 옵션을 제공하여 사용자 경험을 개선했습니다.

## 기대효과
- 사용자 경험 향상: 카카오톡은 한국에서 가장 널리 사용되는 메신저이므로, 사용자가 친구를 더 쉽게 초대할 수 있습니다.
- 초대율 증가: 카카오톡 공유 기능을 통해 초대 링크가 더 많이 전파되어, 플로고의 사용자 유입이 증가할 것으로 기대됩니다

## 주요 구현 사항
- 카카오 SDK 통합:
  - 카카오 JavaScript SDK를 동적으로 로드하여, 카카오톡 공유 기능을 구현했습니다.
  - `window.Kakao` 객체를` TypeScript`에서 인식할 수 있도록 타입 선언을 추가했습니다.
- 초대 링크 공유 기능:
  - 사용자가 "카카오로 초대하기" 버튼을 클릭하면, 카카오톡 공유 모달이 열립니다.
  - 공유 모달에는 플로고의 로고, 제목, 설명, 링크가 포함되어 있습니다.
- 환경변수 관리:
  - 카카오 JavaScript 키를 환경변수(NEXT_PUBLIC_KAKAO_JS_KEY)로 관리하여, 보안을 강화했습니다.
  

