### PR TITLE
Fix: 로그인 시 온보딩, 로그인 페이지 접근 시 home페이지로 리다이렉트

### DIFF
--- a/src/app/(routes)/home/page.tsx
+++ b/src/app/(routes)/home/page.tsx
@@ -1,10 +1,35 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuthStore } from "@/stores/useAuthStore";
 import HomeFeedTemplate from "@/components/templates/HomeFeedTemplate";
-import { useState } from "react";
+import Loading from "@/assets/icons/Loading.svg";
 
 export default function HomePage() {
+  const router = useRouter();
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+  const [isLoading, setIsLoading] = useState(true);
   const [isClosedView, setIsClosedView] = useState(false);
+
+  useEffect(() => {
+    // 초기 로딩이 완료된 후에만 리다이렉트 체크
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isLoading && !isLoggedIn) {
+      router.replace("/login");
+    }
+  }, [router, isLoggedIn, isLoading]);
+
+  if (isLoading || !isLoggedIn) {
+    return (
+      <p className="flex flex-1 items-center justify-center text-center">
+        <Loading className="h-[81px] w-[81px] animate-spin" />
+      </p>
+    );
+  }
 
   return (
     <HomeFeedTemplate

--- a/src/app/(routes)/login/page.tsx
+++ b/src/app/(routes)/login/page.tsx
@@ -1,29 +1,53 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import GoogleLoginButton from "@/components/atoms/Button/GoogleLoginButton";
 import KakaoLoginButton from "@/components/atoms/Button/KakaoLoginButton";
 import IconExclamation from "@/assets/icons/IconExclamation.svg";
+import { useAuthStore } from "@/stores/useAuthStore";
+import Loading from "@/assets/icons/Loading.svg";
 
 export default function LoginPage() {
+  const router = useRouter();
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isLoading && isLoggedIn) {
+      router.replace("/home");
+    }
+  }, [router, isLoggedIn, isLoading]);
+
+  if (isLoading || isLoggedIn) {
+    return (
+      <p className="flex flex-1 items-center justify-center text-center">
+        <Loading className="h-[81px] w-[81px] animate-spin" />
+      </p>
+    );
+  }
+
   return (
     <div className="flex h-screen flex-col items-center justify-center gap-16">
-      <div className="flex flex-col items-center justify-center gap-[1.125rem]">
-        <h1 className="font-gigantic text-green text-[5.25rem]">Ploggo</h1>
-        <p className="text-heading2-bold font-gsans-bold text-green">
+      <div className="flex flex-col items-center gap-2">
+        <h1 className="font-gigantic text-[5.25rem] text-[#59AC6E]">Ploggo</h1>
+        <p className="font-gsans-bold text-lg text-[#59AC6E]">
           동네사람들과 줍깅하기
         </p>
       </div>
-      <div className="flex flex-col gap-[1.375rem]">
-        <div className="flex flex-col items-center justify-center gap-4">
-          <KakaoLoginButton />
-          <GoogleLoginButton />
-        </div>
-        <div className="flex gap-1">
-          <IconExclamation className="h-4 w-4" />
-          <p className="text-grey-400 font-gsans-medium text-body3-medium">
-            안전한 줍깅이 활동을 위해 로그인을 해야 이용 가능해요
-          </p>
-        </div>
+
+      <div className="flex flex-col gap-4">
+        <KakaoLoginButton />
+        <GoogleLoginButton />
+      </div>
+
+      <div className="flex items-center gap-2 text-sm text-gray-500">
+        <IconExclamation className="h-4 w-4" />
+        <p>소셜 로그인으로 간편하게 시작하세요</p>
       </div>
     </div>
   );

--- a/src/app/(routes)/onboarding/page.tsx
+++ b/src/app/(routes)/onboarding/page.tsx
@@ -1,17 +1,31 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { AnimatePresence } from "framer-motion";
 import { ONBOARDING_SLIDES } from "@/constants/onboarding";
 import OnboardingSlide from "@/components/organisms/OnboardingSlide";
 import OnboardingControl from "@/components/organisms/OnboardingControl";
+import { useAuthStore } from "@/stores/useAuthStore";
+import Loading from "@/assets/icons/Loading.svg";
 
 export default function OnboardingPage() {
   const [page, setPage] = useState(0);
   const [direction, setDirection] = useState(0);
   const router = useRouter();
   const total = ONBOARDING_SLIDES.length;
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isLoading && isLoggedIn) {
+      router.replace("/home");
+    }
+  }, [router, isLoggedIn, isLoading]);
 
   const nextPage = () => {
     if (page < total - 1) {
@@ -31,6 +45,14 @@ export default function OnboardingPage() {
   };
   const handleStart = () => router.push("/login");
   const handleNextClick = () => nextPage();
+
+  if (isLoading || isLoggedIn) {
+    return (
+      <p className="flex flex-1 items-center justify-center text-center">
+        <Loading className="h-[81px] w-[81px] animate-spin" />
+      </p>
+    );
+  }
 
   return (
     <div className="flex h-screen flex-col items-center justify-between py-8">

--- a/src/app/(routes)/splash/page.tsx
+++ b/src/app/(routes)/splash/page.tsx
@@ -3,17 +3,23 @@
 import { motion } from "framer-motion";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useAuthStore } from "@/stores/useAuthStore";
 
 export default function SplashPage() {
   const router = useRouter();
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      router.push("/onboarding");
+      if (isLoggedIn) {
+        router.replace("/home");
+      } else {
+        router.replace("/onboarding");
+      }
     }, 2500);
 
     return () => clearTimeout(timer);
-  }, [router]);
+  }, [router, isLoggedIn]);
 
   return (
     <div className="flex h-screen items-center justify-center">

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { devtools, persist } from "zustand/middleware";
+import { devtools, persist, createJSONStorage } from "zustand/middleware";
 
 export interface User {
   id: number;
@@ -35,21 +35,16 @@ export const useAuthStore = create<AuthState>()(
             profileImageUrl: user.profileImageUrl,
           }),
 
-        logout: () => {
-          // 상태 초기화
+        logout: () =>
           set({
             isLoggedIn: false,
             user: null,
-          });
-
-          // localStorage에서 persist된 상태 삭제
-          if (typeof window !== "undefined") {
-            localStorage.removeItem("auth-storage");
-          }
-        },
+            profileImageUrl: null,
+          }),
       }),
       {
-        name: "auth-storage", // localStorage에 저장될 키
+        name: "auth-storage",
+        storage: createJSONStorage(() => localStorage),
       },
     ),
     {


### PR DESCRIPTION
## 작업의 목적
- QA칸반보드 온보딩 무한 출력 문제 해결

## 기대효과
- 로그인 시 온보딩, 로그인 페이지 접근 시 `/home` 페이지로 리다이렉트 됩니다.

## 주요 구현 사항
- useAuthStore에 persist 미들웨어 적용하여 로그인 상태 유지
  - localStorage를 사용하여 페이지 새로고침 시에도 로그인 상태 유지

- 온보딩 페이지(`/onboarding`) 리다이렉트 로직 추가
  - 로그인된 사용자 접근 시` /home`으로 리다이렉트
  - 초기 로딩 상태 관리로 불필요한 리다이렉트 방지

- 로그인 페이지(`/login`) 리다이렉트 로직 추가
  - 로그인된 사용자 접근 시`/home`으로 리다이렉트
  - 초기 로딩 상태 관리로 불필요한 리다이렉트 방지

- 홈 페이지(`/home`) 접근 제어 로직 개선
  - 로그인하지 않은 사용자 접근 시 `/login`으로 리다이렉트
  - 초기 로딩 상태 관리로 불필요한 리다이렉트 방지
  

