### PR TITLE
Fix: 모임 목록 조회(홈 피드, 모임 메뉴)에 무한 스크롤 적용되지 않았던 문제 해결

### DIFF
--- a/src/components/organisms/gatherings/GatheringList.tsx
+++ b/src/components/organisms/gatherings/GatheringList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import DateBadge from "@/components/atoms/Badge/DateBadge";
+import useIntersectionObserver from "@/hooks/features/commons/useIntersectionObserver";
 import { useFetchCompletedGatheringList } from "@/hooks/queries/useFetchGatheringList";
 import { getDay, getDayOfWeek, getMonth } from "@/utils/day";
 import { groupGatheringsByDate } from "@/utils/gatherings";
@@ -8,7 +9,12 @@ import Empty from "../Empty";
 import GatheringItem from "./GatheringItem";
 
 export default function GatheringList() {
-  const { data, isLoading } = useFetchCompletedGatheringList();
+  const { data, isLoading, fetchNextPage, hasNextPage } =
+    useFetchCompletedGatheringList();
+  const { setTarget } = useIntersectionObserver({
+    fetchNextPage,
+    hasNextPage,
+  });
 
   if (!data && !isLoading) return null;
 
@@ -39,6 +45,7 @@ export default function GatheringList() {
             </div>
           </div>
         ))}
+      <div ref={setTarget} />
       {isEmpty && <Empty largeText="완료된 모임이 없어요" />}
     </div>
   );

--- a/src/components/templates/GatheringsCreatePage.tsx
+++ b/src/components/templates/GatheringsCreatePage.tsx
@@ -183,7 +183,7 @@ export default function GatheringsCreatePage() {
 
         <CreateButton
           isActive={isActive}
-          message="모임장은 모인 후에 최소 사진 1장을 올려주셔야 해요"
+          message="모임장은 모임 후에 최소 사진 1장을 올려주셔야 해요"
         >
           완료
         </CreateButton>

--- a/src/components/templates/HomeFeedTemplate.tsx
+++ b/src/components/templates/HomeFeedTemplate.tsx
@@ -103,19 +103,21 @@ export default function HomeFeedTemplate({
             />
           </div>
         ) : (
-          groupedList.map((items) => {
-            const date = formatDate(items[0].meetingTime, "yyyy-MM-dd");
-            return (
-              <div key={date}>
-                <GatheringListGroup
-                  date={date}
-                  items={items}
-                  isClosed={isClosedView}
-                />
-                <div className="h-4" ref={setTarget}></div>
-              </div>
-            );
-          })
+          <>
+            {groupedList.map((items) => {
+              const date = formatDate(items[0].meetingTime, "yyyy-MM-dd");
+              return (
+                <div key={date}>
+                  <GatheringListGroup
+                    date={date}
+                    items={items}
+                    isClosed={isClosedView}
+                  />
+                </div>
+              );
+            })}
+            <div ref={setTarget} />
+          </>
         )}
       </div>
 

--- a/src/components/templates/ProfilePage.tsx
+++ b/src/components/templates/ProfilePage.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
 import { getUserProfile } from "@/api/profile/getUserProfile";
-import InfoBox from "@/components/atoms/InfoBox/InfoBox";
-import ActivityRow from "@/components/molecules/ActivityRow";
-import SectionWithTitle from "@/components/organisms/profile/SectionWithTitle";
-import ProfileHeader from "@/components/organisms/profile/ProfileHeader";
+import IconAddNew from "@/assets/icons/IconAddNew.svg";
 import IconGroup from "@/assets/icons/IconGroup01.svg";
 import IconLocation from "@/assets/icons/IconLocation.svg";
-import IconAddNew from "@/assets/icons/IconAddNew.svg";
 import IconMedal from "@/assets/icons/IconMedal01.svg";
 import IconMegaphone from "@/assets/icons/IconMegaphone.svg";
+import InfoBox from "@/components/atoms/InfoBox/InfoBox";
+import ActivityRow from "@/components/molecules/ActivityRow";
+import ProfileHeader from "@/components/organisms/profile/ProfileHeader";
+import SectionWithTitle from "@/components/organisms/profile/SectionWithTitle";
+import { useQuery } from "@tanstack/react-query";
 
 export default function ProfilePage() {
   const { data: profile, isLoading } = useQuery({
@@ -22,7 +22,7 @@ export default function ProfilePage() {
   if (isLoading || !profile) return <p className="text-center">로딩 중...</p>;
 
   return (
-    <main className="h-full w-full px-4 py-6 text-sm">
+    <main className="bottom-padding h-full w-full px-4 py-6 text-sm">
       <h1 className="text-heading1-medium font-gsans-medium mb-6 text-center">
         프로필
       </h1>

--- a/src/hooks/queries/useFetchGatheringList.ts
+++ b/src/hooks/queries/useFetchGatheringList.ts
@@ -10,7 +10,7 @@ import {
 } from "@/types/gatherings";
 import { useInfiniteQuery } from "@tanstack/react-query";
 
-const ROWS_PER_PAGE = 20;
+const ROWS_PER_PAGE = 10;
 
 /** 홈 화면 - 모집중/마감된 모임 */
 export const useFetchGatheringList = (


### PR DESCRIPTION
## 작업의 목적
- 모임 목록 조회(홈 피드, 모임 메뉴)에 무한 스크롤 적용되지 않았던 문제 해결

## 기대효과
- 포트폴리오에 활용할 예정이니 자세하게 적어주세요

## 주요 구현 사항
- 각 페이지에서 `useInfiniteObverserver` 훅 호출 및 ref 적용
- 텍스트 오타 수정 ('모인' -> '모임')
- 프로필 메인 화면의 푸터 사이즈만큼 바닥 패딩 적용
  
