### PR TITLE
Fix: 공통 Modal의 패딩을 제거하고, 각 컴포넌트에서 패딩을 부여

### DIFF
--- a/src/components/atoms/Modal/Modal.tsx
+++ b/src/components/atoms/Modal/Modal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import IconClose from "@/assets/icons/IconClose.svg";
 import { useEffect } from "react";
 
 interface ModalProps {
@@ -52,7 +53,7 @@ export default function Modal({
             onClick={onClose}
             className="absolute top-6 right-5 cursor-pointer text-2xl"
           >
-            ×
+            <IconClose className="text-grey-950 h-6 w-6" />
           </button>
         )}
         {children}

--- a/src/components/molecules/RegionSelectorModal.tsx
+++ b/src/components/molecules/RegionSelectorModal.tsx
@@ -23,7 +23,9 @@ export default function RegionSelectorModal({
 
   return (
     <Modal onClose={onClose} position="bottom">
-      <RegionPicker onComplete={handleComplete} />
+      <div className="mt-[62px]">
+        <RegionPicker onComplete={handleComplete} />
+      </div>
     </Modal>
   );
 }

--- a/src/components/molecules/input/InputWithModal.tsx
+++ b/src/components/molecules/input/InputWithModal.tsx
@@ -54,13 +54,15 @@ function InputWithModal({
       </div>
       {isOpen && (
         <Modal onClose={handleModalClose}>
-          <TwoButtonContents
-            onClose={handleModalClose}
-            onConfirm={handleModalConfirm}
-            buttonText={{ close: "취소", confirm: "확인" }}
-          >
-            {children}
-          </TwoButtonContents>
+          <div className="mx-[22px] mt-[66px] mb-[30px]">
+            <TwoButtonContents
+              onClose={handleModalClose}
+              onConfirm={handleModalConfirm}
+              buttonText={{ close: "취소", confirm: "확인" }}
+            >
+              {children}
+            </TwoButtonContents>
+          </div>
         </Modal>
       )}
     </div>

--- a/src/components/organisms/region/RegionPicker.tsx
+++ b/src/components/organisms/region/RegionPicker.tsx
@@ -30,7 +30,7 @@ export default function RegionPicker({
   return (
     <div
       className={clsx(
-        "flex h-full max-h-[calc(100vh-6rem)] flex-col gap-9 pt-[62px]",
+        "flex h-full max-h-[calc(100vh-6rem)] flex-col gap-9",
         className,
       )}
     >


### PR DESCRIPTION
## 작업의 목적
- Modal을 사용하는 각 컴포넌트마다 padding 값이 모두 달라서, 
- Modal 공통 컴포넌트의 padding을 제거 -> Modal을 사용하는 컴포넌트에서 `<div className="pt-[62px]">` 로 감싸 조절

