### PR TITLE
Fix: 프로필 페이지 userProfile queryKey 수정을 통해 지역 설정 변경 오류 해결 및 뱃지 진행상황 표기 오류 수정

### DIFF
--- a/src/app/(routes)/profile/badge/page.tsx
+++ b/src/app/(routes)/profile/badge/page.tsx
@@ -20,6 +20,7 @@ export default function BadgePage() {
   const acquiredBadges = userBadge.length;
   const hasAllBadges = acquiredBadges >= BADGES.length;
 
+  const nextBadge = BADGES[acquiredBadges] ?? null;
   const currentBadge = BADGES[acquiredBadges - 1] ?? null;
 
   const grantedDate = latestBadge?.grantedAt
@@ -33,8 +34,11 @@ export default function BadgePage() {
   );
 
   // 누적 progress 값 계산
-  const progressTotal = currentBadge?.required ?? 0;
-  const progressCurrent = progressTotal + remainingActionsForNextBadge;
+  const progressTotal = nextBadge?.required ?? 0;
+  const progressCurrent = Math.max(
+    0,
+    progressTotal + remainingActionsForNextBadge,
+  );
 
   if (isLoading) {
     return <p className="text-center">로딩 중...</p>;

--- a/src/components/templates/ProfilePage.tsx
+++ b/src/components/templates/ProfilePage.tsx
@@ -14,7 +14,7 @@ import { useQuery } from "@tanstack/react-query";
 
 export default function ProfilePage() {
   const { data: profile, isLoading } = useQuery({
-    queryKey: ["userprofile"],
+    queryKey: ["userProfile"],
     queryFn: getUserProfile,
     refetchOnMount: true,
   });

--- a/src/hooks/mutations/useUpdateRegion.ts
+++ b/src/hooks/mutations/useUpdateRegion.ts
@@ -12,7 +12,7 @@ export const useUpdateRegion = () => {
     mutationFn: updateRegion,
     onSuccess: async (_, region) => {
       setRegion(region);
-      await queryClient.invalidateQueries({ queryKey: ["userprofile"] });
+      await queryClient.invalidateQueries({ queryKey: ["userProfile"] });
       router.push("/profile");
     },
     onError: () => {


### PR DESCRIPTION
## 작업의 목적
- 프로필 페이지에서 지역 변경 시 홈 피드 화면에서 바로 반영되지 않던 문제 해결
- 뱃지 진행상황 표기 오류 해결

## 기대효과
- 내 뱃지 페이지의 진행 상황이 음수 표시 수정
-  프로필 페이지에서 지역 변경 시 홈 피드 화면에서도 바로 반영

## 주요 구현 사항
- 프로필 페이지의 지역 설정 변경 시에 사용하던 queryKey 수정(다른 Profile관련 훅들과 일치하도록 수정)을 통해 해결
- 뱃지의 진행 상황 표시를 currentBadge가 아닌 NextBadge기준으로 표시하도록 변경
  
closed #이슈번호
